### PR TITLE
Рефакторинг: перенос утилит и функций по классам

### DIFF
--- a/dl_utils.py
+++ b/dl_utils.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Вспомогательные функции для проекта DAMP-light."""
+
+import math
+from typing import Set, Tuple, List
+
+import numpy as np
+from torchvision import transforms
+from torchvision.datasets import MNIST
+
+
+def cosbin(a: Set[int], b: Set[int]) -> float:
+    if not a or not b:
+        return 0.0
+    inter = len(a & b)
+    return inter / math.sqrt(len(a) * len(b))
+
+
+def to01(img8x8: np.ndarray) -> np.ndarray:
+    """Нормирует массив 0..16 в диапазон 0..1."""
+    return (img8x8.astype(np.float32) / 16.0).reshape(8, 8)
+
+
+def load_mnist_28x28(train_limit=8000, test_limit=2000, seed=0):
+    """Грузит и подсэмплирует MNIST (28×28, 0..1)."""
+    tfm = transforms.ToTensor()
+    train_ds = MNIST(root="./data", train=True, download=True, transform=tfm)
+    test_ds = MNIST(root="./data", train=False, download=True, transform=tfm)
+
+    rng = np.random.default_rng(seed)
+    train_idx = np.arange(len(train_ds))
+    test_idx = np.arange(len(test_ds))
+
+    if train_limit and len(train_idx) > train_limit:
+        train_idx = rng.choice(train_idx, size=train_limit, replace=False)
+    if test_limit and len(test_idx) > test_limit:
+        test_idx = rng.choice(test_idx, size=test_limit, replace=False)
+
+    X_train = [train_ds[i][0].squeeze(0).numpy().astype(np.float32) for i in train_idx]
+    y_train = [int(train_ds[i][1]) for i in train_idx]
+    X_test = [test_ds[i][0].squeeze(0).numpy().astype(np.float32) for i in test_idx]
+    y_test = [int(test_ds[i][1]) for i in test_idx]
+    return X_train, X_test, y_train, y_test
+

--- a/main.py
+++ b/main.py
@@ -7,10 +7,8 @@ from sklearn.datasets import load_digits
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import accuracy_score, classification_report, confusion_matrix
 
-from damp_light import (
-    KNNJaccard,
-    load_mnist_28x28, to01
-)
+from damp_light import KNNJaccard
+from dl_utils import load_mnist_28x28, to01
 from training_cache import load_or_train
 from viz import save_embedding_core_heatmap, show_semantic_closeness, visualize_pipeline, save_class_overlay_pdf
 

--- a/viz.py
+++ b/viz.py
@@ -480,7 +480,7 @@ def show_semantic_closeness(Z: List[Set[int]], y: List[int], det: DetectorSpace,
     Mt = np.zeros((C, C), dtype=np.float32)  # Tanimoto по частотам
     for i in range(C):
         for j in range(C):
-            Mj[i, j] = jaccard(S[i], S[j])
+            Mj[i, j] = KNNJaccard.jaccard(S[i], S[j])
             Mt[i, j] = _tanimoto(F[i], F[j])
 
     # --- Heatmap: Жаккар по наборам ---
@@ -534,8 +534,8 @@ def show_semantic_closeness(Z: List[Set[int]], y: List[int], det: DetectorSpace,
         if y[i] != y[j]:
             diff_pairs.append((i, j))
 
-    js_same = np.array([jaccard(Z[i], Z[j]) for (i, j) in same_pairs], dtype=np.float32) if same_pairs else np.array([0.0])
-    js_diff = np.array([jaccard(Z[i], Z[j]) for (i, j) in diff_pairs], dtype=np.float32) if diff_pairs else np.array([0.0])
+    js_same = np.array([KNNJaccard.jaccard(Z[i], Z[j]) for (i, j) in same_pairs], dtype=np.float32) if same_pairs else np.array([0.0])
+    js_diff = np.array([KNNJaccard.jaccard(Z[i], Z[j]) for (i, j) in diff_pairs], dtype=np.float32) if diff_pairs else np.array([0.0])
 
     plt.figure(figsize=(6.8, 4.2))
     bins = np.linspace(0, 1, 41)


### PR DESCRIPTION
## Сводка
- Вынес общие вспомогательные процедуры в отдельный модуль `dl_utils`
- Перенёс вспомогательные методы внутрь соответствующих классов `PrimaryEncoder`, `DetectorSpace` и `KNNJaccard`
- Обновил импорты и использование Жаккара в основной логике и визуализации

## Тестирование
- `python -m py_compile damp_light.py dl_utils.py main.py viz.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7e6792bf4832e8e31ba35e2d07b54