### PR TITLE
Ограничить соседей радиусом в Layout2D

### DIFF
--- a/src/Layout2D.py
+++ b/src/Layout2D.py
@@ -27,6 +27,7 @@ class Layout2D:
         for dy in range(-R, R + 1):
             for dx in range(-R, R + 1):
                 if dy == 0 and dx == 0: continue
+                if math.hypot(dy, dx) > R: continue
                 ny, nx = y + dy, x + dx
                 if 0 <= ny < H and 0 <= nx < W: out.append((ny, nx))
         return out


### PR DESCRIPTION
## Описание
- добавлена фильтрация соседей по евклидовому радиусу в Layout2D, чтобы соответствовать круговому окну поиска

## Проверки
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68cd985e9d24832e97c09537f66bf46c