### PR TITLE
Добавление косинусной близости кодов

### DIFF
--- a/src/RandomKeyholeSamplingEncoder.py
+++ b/src/RandomKeyholeSamplingEncoder.py
@@ -143,7 +143,34 @@ class RandomKeyholeSamplingEncoder:
         label_repr = self.current_img_label if self.current_img_label is not None else "(метка не задана)"
         print(f"Метка класса: {label_repr}")
 
-        for ang, code in recs:
+        prev_code: Optional[Set[int]] = None
+        first_code: Optional[Set[int]] = recs[0][1] if recs else None
+        total_recs = len(recs)
+
+        def _print_overlap(prefix: str, code_a: Set[int], code_b: Set[int]) -> None:
+            shared = len(code_a & code_b)
+            union = len(code_a | code_b)
+            overlap_pct = 100.0 if union == 0 else (shared / union) * 100.0
+
+            len_a = len(code_a)
+            len_b = len(code_b)
+            if len_a == 0 and len_b == 0:
+                cosine_val = 1.0
+            elif len_a == 0 or len_b == 0:
+                cosine_val = 0.0
+            else:
+                cosine_val = shared / math.sqrt(len_a * len_b)
+
+            print(
+                f"    ∩ {prefix}: "
+                f"{overlap_pct:6.2f}% ({shared}/{union} битов); "
+                f"cos={cosine_val:6.4f}"
+            )
+
+        for idx, (ang, code) in enumerate(recs):
+            if prev_code is not None:
+                _print_overlap("с предыдущим", prev_code, code)
+
             deg = ang * 180.0 / np.pi
             if as_barcode:
                 s = self._bits_to_barcode(code)
@@ -151,6 +178,9 @@ class RandomKeyholeSamplingEncoder:
                 inds = sorted(int(b) for b in code)
                 s = f"indices={inds}"
             print(f"{ang:.6f} rad ({deg:7.2f}°): {s}")
+            if idx == total_recs - 1 and first_code is not None and total_recs > 1:
+                _print_overlap("с первым", code, first_code)
+            prev_code = code
 
 
     # ==================== ВНУТРЕННЕЕ ====================

--- a/src/RandomKeyholeSamplingEncoder.py
+++ b/src/RandomKeyholeSamplingEncoder.py
@@ -161,11 +161,7 @@ class RandomKeyholeSamplingEncoder:
             else:
                 cosine_val = shared / math.sqrt(len_a * len_b)
 
-            print(
-                f"    ∩ {prefix}: "
-                f"{overlap_pct:6.2f}% ({shared}/{union} битов); "
-                f"cos={cosine_val:6.4f}"
-            )
+            print(f"∩ {prefix}: {overlap_pct:6.2f}% ({shared}/{union} бит); cos: {(cosine_val*100):6.2f}%")
 
         for idx, (ang, code) in enumerate(recs):
             if prev_code is not None:

--- a/src/run.py
+++ b/src/run.py
@@ -43,17 +43,6 @@ def rgb_from_bits(bits: Set[int]) -> Tuple[int, int, int]:
     return (h[0], h[1], h[2])
 
 
-def rr_log_layout_bits(lay: Layout2D, codes: List[Set[int]], enc, tag="layout", step=0):
-    N = len(codes)
-    pos = np.zeros((N, 2), dtype=np.float32)
-    col = np.zeros((N, 3), dtype=np.uint8)
-    for i in range(N):
-        y, x = lay.position_of(i)
-        pos[i] = (x, y)
-        col[i] = np.array(rgb_from_bits(codes[i]), dtype=np.uint8)
-    rr.set_time("step", sequence=step)
-    rr.log(f"{tag}", rr.Points2D(positions=pos, colors=col, radii=0.6))
-
 def rgb_from_angle(angle_rad: float):
     h = (angle_rad / (np.pi*2)) % 1.0
     r, g, b = (hsv_to_rgb([[h, 1.0, 1.0]])[0] * 255).astype(np.uint8)
@@ -82,7 +71,7 @@ def rr_log_layout_ang(
             angle, _ = enc.code_dominant_orientation(code)
         col[i] = np.array(rgb_from_angle(angle), dtype=np.uint8)
         angle_deg = np.degrees(angle)
-        labels.append(f"угол={angle_deg:.1f}°")
+        labels.append(f"{angle_deg:.2f}°")
     timeline_step = step
     if isinstance(tag, str):
         phase_name = tag.rsplit("/", 1)[-1]
@@ -118,7 +107,7 @@ def run() -> None:
         )
 
 
-    X_train, X_test, y_train, y_test = load_mnist_28x28(train_limit=10, test_limit=0, seed=2)
+    X_train, X_test, y_train, y_test = load_mnist_28x28(train_limit=10, test_limit=0, seed=11)
 
     enc = RandomKeyholeSamplingEncoder(
         img_hw=(28, 28),


### PR DESCRIPTION
## Резюме
- добавлена печать косинусной близости между соседними кодами скважин
- добавлен вывод доли пересечения соседних кодов в процентах
- добавлен вывод перекрытия и косинусной близости последнего кода с первым

## Тестирование
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68cfbcdc266c832e88112d99e7e00dab