### PR TITLE
Перенос Layout2D на ProcessPoolExecutor

### DIFF
--- a/src/Layout2D.py
+++ b/src/Layout2D.py
@@ -1,4 +1,5 @@
 import math
+import os
 import random
 from concurrent.futures import ProcessPoolExecutor
 from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple
@@ -10,9 +11,13 @@ WorkerState = Tuple[
     float,
 ]
 
+CacheToken = Tuple[str, int, int]
+
 NeighborInfo = Sequence[Tuple[Tuple[int, int], float, Optional[int]]]
 
 _WORKER_STATE: WorkerState = ((), (), None, 0.0)
+_WORKER_SIM_CACHE: Dict[Tuple[int, int], float] = {}
+_WORKER_CACHE_TOKEN: Optional[CacheToken] = None
 
 
 def _init_worker_state(
@@ -21,8 +26,10 @@ def _init_worker_state(
     aux_vecs: Optional[Sequence[Optional[Tuple[float, ...]]]],
     aux_weight: float,
 ) -> None:
-    global _WORKER_STATE
+    global _WORKER_STATE, _WORKER_SIM_CACHE, _WORKER_CACHE_TOKEN
     _WORKER_STATE = (code_bitmasks, code_norms, aux_vecs, aux_weight)
+    _WORKER_SIM_CACHE = {}
+    _WORKER_CACHE_TOKEN = None
 
 
 def _compute_similarity(idx_a: int, idx_b: int, state: WorkerState) -> float:
@@ -107,9 +114,14 @@ def evaluate_pair_worker(
         Tuple[int, int],
         NeighborInfo,
         NeighborInfo,
+        CacheToken,
     ]
 ) -> Tuple[int, Tuple[int, int], int, Tuple[int, int], float, float]:
-    ia, yxa, ib, yxb, neighbors_a, neighbors_b = task
+    global _WORKER_CACHE_TOKEN
+    ia, yxa, ib, yxb, neighbors_a, neighbors_b, cache_token = task
+    if cache_token != _WORKER_CACHE_TOKEN:
+        _WORKER_SIM_CACHE.clear()
+        _WORKER_CACHE_TOKEN = cache_token
     return _evaluate_pair_core(
         ia,
         yxa,
@@ -118,7 +130,7 @@ def evaluate_pair_worker(
         neighbors_a,
         neighbors_b,
         state=None,
-        sim_cache=None,
+        sim_cache=_WORKER_SIM_CACHE,
     )
 
 
@@ -282,8 +294,11 @@ class Layout2D:
             self._cell_owner_grid[yx[0]][yx[1]] = i
 
         executor: Optional[ProcessPoolExecutor] = None
+        worker_count = 0
         if len(cells) > 1:
+            worker_count = min(os.cpu_count() or 1, len(cells))
             executor = ProcessPoolExecutor(
+                max_workers=worker_count,
                 initializer=_init_worker_state,
                 initargs=(
                     self._code_bitmasks,
@@ -346,6 +361,7 @@ class Layout2D:
                                 self._cell_owner_grid[yxb[0]][yxb[1]] = ia
                                 if on_swap: on_swap(yxa, yxb, phase, ep, self)
                 else:
+                    cache_token: CacheToken = (phase, ep, R)
                     tasks = []
                     for ia, yxa, ib, yxb in pairs:
                         neighbors_a: NeighborInfo = tuple(
@@ -356,9 +372,25 @@ class Layout2D:
                             ((ny, nx), dist, self._cell_owner_grid[ny][nx])
                             for (ny, nx), dist in self._neighbors(yxb[0], yxb[1], R)
                         )
-                        tasks.append((ia, yxa, ib, yxb, neighbors_a, neighbors_b))
+                        tasks.append(
+                            (
+                                ia,
+                                yxa,
+                                ib,
+                                yxb,
+                                neighbors_a,
+                                neighbors_b,
+                                cache_token,
+                            )
+                        )
+                    if worker_count:
+                        chunk = max(1, len(tasks) // (worker_count * 4))
+                    else:
+                        chunk = 1
                     for ia, yxa, ib, yxb, e_cur, e_swp in executor.map(
-                        evaluate_pair_worker, tasks
+                        evaluate_pair_worker,
+                        tasks,
+                        chunksize=chunk,
                     ):
                         if phase == "far":
                             if e_swp + 1e-9 < e_cur:

--- a/src/Layout2D.py
+++ b/src/Layout2D.py
@@ -4,18 +4,22 @@ import random
 from concurrent.futures import ProcessPoolExecutor
 from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple
 
+NeighborEntry = Tuple[Tuple[int, int], float]
+NeighborMap = Dict[Tuple[int, int], Sequence[NeighborEntry]]
+NeighborCache = Dict[int, NeighborMap]
+NeighborOwners = Sequence[int]
+
 WorkerState = Tuple[
     Sequence[int],
     Sequence[float],
     Optional[Sequence[Optional[Tuple[float, ...]]]],
     float,
+    NeighborCache,
 ]
 
 CacheToken = Tuple[str, int, int]
 
-NeighborInfo = Sequence[Tuple[Tuple[int, int], float, Optional[int]]]
-
-_WORKER_STATE: WorkerState = ((), (), None, 0.0)
+_WORKER_STATE: WorkerState = ((), (), None, 0.0, {})
 _WORKER_SIM_CACHE: Dict[Tuple[int, int], float] = {}
 _WORKER_CACHE_TOKEN: Optional[CacheToken] = None
 
@@ -25,15 +29,16 @@ def _init_worker_state(
     code_norms: Sequence[float],
     aux_vecs: Optional[Sequence[Optional[Tuple[float, ...]]]],
     aux_weight: float,
+    neighbor_cache: NeighborCache,
 ) -> None:
     global _WORKER_STATE, _WORKER_SIM_CACHE, _WORKER_CACHE_TOKEN
-    _WORKER_STATE = (code_bitmasks, code_norms, aux_vecs, aux_weight)
+    _WORKER_STATE = (code_bitmasks, code_norms, aux_vecs, aux_weight, neighbor_cache)
     _WORKER_SIM_CACHE = {}
     _WORKER_CACHE_TOKEN = None
 
 
 def _compute_similarity(idx_a: int, idx_b: int, state: WorkerState) -> float:
-    code_bitmasks, code_norms, aux_vecs, aux_weight = state
+    code_bitmasks, code_norms, aux_vecs, aux_weight, _ = state
     a, b = (idx_a, idx_b) if idx_a <= idx_b else (idx_b, idx_a)
     denom = code_norms[a] * code_norms[b]
     if denom == 0.0:
@@ -55,13 +60,20 @@ def _evaluate_pair_core(
     yxa: Tuple[int, int],
     ib: int,
     yxb: Tuple[int, int],
-    neighbors_a: NeighborInfo,
-    neighbors_b: NeighborInfo,
+    owners_a: NeighborOwners,
+    owners_b: NeighborOwners,
+    radius: int,
     state: Optional[WorkerState] = None,
     sim_cache: Optional[Dict[Tuple[int, int], float]] = None,
 ) -> Tuple[int, Tuple[int, int], int, Tuple[int, int], float, float]:
     if state is None:
         state = _WORKER_STATE
+
+    neighbor_cache = state[4]
+    neighbors_a_entries = neighbor_cache[radius][yxa]
+    neighbors_b_entries = neighbor_cache[radius][yxb]
+    assert len(neighbors_a_entries) == len(owners_a)
+    assert len(neighbors_b_entries) == len(owners_b)
 
     def similarity(idx1: int, idx2: int) -> float:
         key = (idx1, idx2) if idx1 <= idx2 else (idx2, idx1)
@@ -76,31 +88,33 @@ def _evaluate_pair_core(
 
     def local_energy(
         center_idx: int,
-        neighbors: NeighborInfo,
-        overrides: Dict[Tuple[int, int], Optional[int]],
+        neighbor_entries: Sequence[NeighborEntry],
+        neighbor_owners: NeighborOwners,
+        overrides: Dict[Tuple[int, int], int],
     ) -> float:
         energy = 0.0
-        for cell_coord, dist, neighbor_idx in neighbors:
-            idx = overrides.get(cell_coord, neighbor_idx)
-            if idx is None:
+        for (cell_coord, dist), owner in zip(neighbor_entries, neighbor_owners):
+            override_owner = overrides.get(cell_coord)
+            idx = owner if override_owner is None else override_owner
+            if idx < 0:
                 continue
             energy += similarity(center_idx, idx) * dist
         return energy
 
-    overrides_left: Dict[Tuple[int, int], Optional[int]] = {}
-    overrides_right: Dict[Tuple[int, int], Optional[int]] = {}
+    overrides_left: Dict[Tuple[int, int], int] = {}
+    overrides_right: Dict[Tuple[int, int], int] = {}
 
     current = (
-        local_energy(ia, neighbors_a, overrides_left)
-        + local_energy(ib, neighbors_b, overrides_right)
+        local_energy(ia, neighbors_a_entries, owners_a, overrides_left)
+        + local_energy(ib, neighbors_b_entries, owners_b, overrides_right)
     )
 
     overrides_left[yxb] = ia
     overrides_right[yxa] = ib
 
     swapped = (
-        local_energy(ib, neighbors_a, overrides_left)
-        + local_energy(ia, neighbors_b, overrides_right)
+        local_energy(ib, neighbors_a_entries, owners_a, overrides_left)
+        + local_energy(ia, neighbors_b_entries, owners_b, overrides_right)
     )
 
     return ia, yxa, ib, yxb, current, swapped
@@ -112,13 +126,14 @@ def evaluate_pair_worker(
         Tuple[int, int],
         int,
         Tuple[int, int],
-        NeighborInfo,
-        NeighborInfo,
+        NeighborOwners,
+        NeighborOwners,
         CacheToken,
+        int,
     ]
 ) -> Tuple[int, Tuple[int, int], int, Tuple[int, int], float, float]:
     global _WORKER_CACHE_TOKEN
-    ia, yxa, ib, yxb, neighbors_a, neighbors_b, cache_token = task
+    ia, yxa, ib, yxb, owners_a, owners_b, cache_token, radius = task
     if cache_token != _WORKER_CACHE_TOKEN:
         _WORKER_SIM_CACHE.clear()
         _WORKER_CACHE_TOKEN = cache_token
@@ -127,8 +142,9 @@ def evaluate_pair_worker(
         yxa,
         ib,
         yxb,
-        neighbors_a,
-        neighbors_b,
+        owners_a,
+        owners_b,
+        radius,
         state=None,
         sim_cache=_WORKER_SIM_CACHE,
     )
@@ -148,7 +164,7 @@ class Layout2D:
         self._code_norms: List[float] = []
         self._code_bitmasks: List[int] = []
         self._cell_owner_grid: List[List[Optional[int]]] = []
-        self._neighbor_cache: Dict[int, Dict[Tuple[int, int], Sequence[Tuple[Tuple[int, int], float]]]] = {}
+        self._neighbor_cache: NeighborCache = {}
         self._aux_vecs: Optional[List[Optional[Tuple[float, ...]]]] = None
         self._aux_weight: float = 0.0
 
@@ -164,7 +180,7 @@ class Layout2D:
             bitmask |= 1 << bit
         return bitmask
 
-    def _neighbors(self, y: int, x: int, R: int) -> Sequence[Tuple[Tuple[int, int], float]]:
+    def _neighbors(self, y: int, x: int, R: int) -> Sequence[NeighborEntry]:
         return self._neighbor_cache[R][(y, x)]
 
     @staticmethod
@@ -186,6 +202,7 @@ class Layout2D:
             self._code_norms,
             self._aux_vecs,
             self._aux_weight,
+            self._neighbor_cache,
         )
         key = (ia, ib) if ia <= ib else (ib, ia)
         if cache is not None:
@@ -305,6 +322,7 @@ class Layout2D:
                     self._code_norms,
                     self._aux_vecs,
                     self._aux_weight,
+                    self._neighbor_cache,
                 ),
             )
 
@@ -313,9 +331,18 @@ class Layout2D:
             self._code_norms,
             self._aux_vecs,
             self._aux_weight,
+            self._neighbor_cache,
         )
 
         def pass_epoch(R: int, iters: int, phase: str):
+
+            def gather_owners(yx: Tuple[int, int]) -> Tuple[int, ...]:
+                owners: List[int] = []
+                for (ny, nx), _ in self._neighbors(yx[0], yx[1], R):
+                    holder = self._cell_owner_grid[ny][nx]
+                    owners.append(holder if holder is not None else -1)
+                return tuple(owners)
+
             for ep in range(iters):
                 occupied = list(self.idx2cell.items());
                 self.rng.shuffle(occupied)
@@ -330,21 +357,16 @@ class Layout2D:
                 if not use_parallel:
                     sim_cache: Dict[Tuple[int, int], float] = {}
                     for ia, yxa, ib, yxb in pairs:
-                        neighbors_a: NeighborInfo = tuple(
-                            ((ny, nx), dist, self._cell_owner_grid[ny][nx])
-                            for (ny, nx), dist in self._neighbors(yxa[0], yxa[1], R)
-                        )
-                        neighbors_b: NeighborInfo = tuple(
-                            ((ny, nx), dist, self._cell_owner_grid[ny][nx])
-                            for (ny, nx), dist in self._neighbors(yxb[0], yxb[1], R)
-                        )
+                        owners_a = gather_owners(yxa)
+                        owners_b = gather_owners(yxb)
                         _, _, _, _, e_cur, e_swp = _evaluate_pair_core(
                             ia,
                             yxa,
                             ib,
                             yxb,
-                            neighbors_a,
-                            neighbors_b,
+                            owners_a,
+                            owners_b,
+                            R,
                             state=state_for_local,
                             sim_cache=sim_cache,
                         )
@@ -364,23 +386,18 @@ class Layout2D:
                     cache_token: CacheToken = (phase, ep, R)
                     tasks = []
                     for ia, yxa, ib, yxb in pairs:
-                        neighbors_a: NeighborInfo = tuple(
-                            ((ny, nx), dist, self._cell_owner_grid[ny][nx])
-                            for (ny, nx), dist in self._neighbors(yxa[0], yxa[1], R)
-                        )
-                        neighbors_b: NeighborInfo = tuple(
-                            ((ny, nx), dist, self._cell_owner_grid[ny][nx])
-                            for (ny, nx), dist in self._neighbors(yxb[0], yxb[1], R)
-                        )
+                        owners_a = gather_owners(yxa)
+                        owners_b = gather_owners(yxb)
                         tasks.append(
                             (
                                 ia,
                                 yxa,
                                 ib,
                                 yxb,
-                                neighbors_a,
-                                neighbors_b,
+                                owners_a,
+                                owners_b,
                                 cache_token,
+                                R,
                             )
                         )
                     if worker_count:

--- a/src/Layout2D.py
+++ b/src/Layout2D.py
@@ -1,8 +1,125 @@
 import math
 import random
-import threading
-from concurrent.futures import ThreadPoolExecutor, wait
+from concurrent.futures import ProcessPoolExecutor
 from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple
+
+WorkerState = Tuple[
+    Sequence[int],
+    Sequence[float],
+    Optional[Sequence[Optional[Tuple[float, ...]]]],
+    float,
+]
+
+NeighborInfo = Sequence[Tuple[Tuple[int, int], float, Optional[int]]]
+
+_WORKER_STATE: WorkerState = ((), (), None, 0.0)
+
+
+def _init_worker_state(
+    code_bitmasks: Sequence[int],
+    code_norms: Sequence[float],
+    aux_vecs: Optional[Sequence[Optional[Tuple[float, ...]]]],
+    aux_weight: float,
+) -> None:
+    global _WORKER_STATE
+    _WORKER_STATE = (code_bitmasks, code_norms, aux_vecs, aux_weight)
+
+
+def _compute_similarity(idx_a: int, idx_b: int, state: WorkerState) -> float:
+    code_bitmasks, code_norms, aux_vecs, aux_weight = state
+    a, b = (idx_a, idx_b) if idx_a <= idx_b else (idx_b, idx_a)
+    denom = code_norms[a] * code_norms[b]
+    if denom == 0.0:
+        sim = 0.0
+    else:
+        inter = (code_bitmasks[a] & code_bitmasks[b]).bit_count()
+        sim = inter / denom
+    if aux_vecs is not None and aux_weight > 0.0:
+        va = aux_vecs[a]
+        vb = aux_vecs[b]
+        if va is not None and vb is not None:
+            dot = sum(ax * bx for ax, bx in zip(va, vb))
+            sim += aux_weight * ((dot + 1.0) * 0.5)
+    return sim
+
+
+def _evaluate_pair_core(
+    ia: int,
+    yxa: Tuple[int, int],
+    ib: int,
+    yxb: Tuple[int, int],
+    neighbors_a: NeighborInfo,
+    neighbors_b: NeighborInfo,
+    state: Optional[WorkerState] = None,
+    sim_cache: Optional[Dict[Tuple[int, int], float]] = None,
+) -> Tuple[int, Tuple[int, int], int, Tuple[int, int], float, float]:
+    if state is None:
+        state = _WORKER_STATE
+
+    def similarity(idx1: int, idx2: int) -> float:
+        key = (idx1, idx2) if idx1 <= idx2 else (idx2, idx1)
+        if sim_cache is not None:
+            cached = sim_cache.get(key)
+            if cached is not None:
+                return cached
+        value = _compute_similarity(idx1, idx2, state)
+        if sim_cache is not None:
+            sim_cache[key] = value
+        return value
+
+    def local_energy(
+        center_idx: int,
+        neighbors: NeighborInfo,
+        overrides: Dict[Tuple[int, int], Optional[int]],
+    ) -> float:
+        energy = 0.0
+        for cell_coord, dist, neighbor_idx in neighbors:
+            idx = overrides.get(cell_coord, neighbor_idx)
+            if idx is None:
+                continue
+            energy += similarity(center_idx, idx) * dist
+        return energy
+
+    overrides_left: Dict[Tuple[int, int], Optional[int]] = {}
+    overrides_right: Dict[Tuple[int, int], Optional[int]] = {}
+
+    current = (
+        local_energy(ia, neighbors_a, overrides_left)
+        + local_energy(ib, neighbors_b, overrides_right)
+    )
+
+    overrides_left[yxb] = ia
+    overrides_right[yxa] = ib
+
+    swapped = (
+        local_energy(ib, neighbors_a, overrides_left)
+        + local_energy(ia, neighbors_b, overrides_right)
+    )
+
+    return ia, yxa, ib, yxb, current, swapped
+
+
+def evaluate_pair_worker(
+    task: Tuple[
+        int,
+        Tuple[int, int],
+        int,
+        Tuple[int, int],
+        NeighborInfo,
+        NeighborInfo,
+    ]
+) -> Tuple[int, Tuple[int, int], int, Tuple[int, int], float, float]:
+    ia, yxa, ib, yxb, neighbors_a, neighbors_b = task
+    return _evaluate_pair_core(
+        ia,
+        yxa,
+        ib,
+        yxb,
+        neighbors_a,
+        neighbors_b,
+        state=None,
+        sim_cache=None,
+    )
 
 
 class Layout2D:
@@ -46,45 +163,36 @@ class Layout2D:
                     return idx
         return default_idx
 
-    def _similarity(self,
-                    ia: int,
-                    ib: int,
-                    cache: Dict[Tuple[int, int], float],
-                    lock: Optional[threading.Lock]) -> float:
-        a, b = (ia, ib) if ia <= ib else (ib, ia)
-        if lock is None:
-            cached = cache.get((a, b))
-        else:
-            with lock:
-                cached = cache.get((a, b))
-        if cached is not None:
-            return cached
-        denom = self._code_norms[a] * self._code_norms[b]
-        if denom == 0.0:
-            sim = 0.0
-        else:
-            inter = (self._code_bitmasks[a] & self._code_bitmasks[b]).bit_count()
-            sim = inter / denom
-        if self._aux_vecs is not None and self._aux_weight > 0.0:
-            va = self._aux_vecs[a]
-            vb = self._aux_vecs[b]
-            if va is not None and vb is not None:
-                dot = sum(ax * bx for ax, bx in zip(va, vb))
-                sim += self._aux_weight * ((dot + 1.0) * 0.5)
-        if lock is None:
-            cache[(a, b)] = sim
-        else:
-            with lock:
-                cache[(a, b)] = sim
-        return sim
+    def _similarity(
+        self,
+        ia: int,
+        ib: int,
+        cache: Optional[Dict[Tuple[int, int], float]] = None,
+    ) -> float:
+        state: WorkerState = (
+            self._code_bitmasks,
+            self._code_norms,
+            self._aux_vecs,
+            self._aux_weight,
+        )
+        key = (ia, ib) if ia <= ib else (ib, ia)
+        if cache is not None:
+            cached = cache.get(key)
+            if cached is not None:
+                return cached
+        value = _compute_similarity(ia, ib, state)
+        if cache is not None:
+            cache[key] = value
+        return value
 
-    def _local_energy(self,
-                      yx,
-                      center_idx,
-                      R,
-                      sim_cache,
-                      cache_lock,
-                      override=None) -> float:
+    def _local_energy(
+        self,
+        yx: Tuple[int, int],
+        center_idx: Optional[int],
+        R: int,
+        sim_cache: Optional[Dict[Tuple[int, int], float]],
+        override=None,
+    ) -> float:
         ci = self._resolve_override(yx, center_idx, override)
         if ci is None:
             return 0.0
@@ -93,21 +201,20 @@ class Layout2D:
             jdx = self._resolve_override((ny, nx), self._cell_owner_grid[ny][nx], override)
             if jdx is None:
                 continue
-            energy += self._similarity(ci, jdx, sim_cache, cache_lock) * dist
+            energy += self._similarity(ci, jdx, sim_cache) * dist
         return energy
 
     def _pair_energy(self,
-                     left_yx,
-                     left_idx,
-                     right_yx,
-                     right_idx,
-                     R,
-                     sim_cache,
-                     cache_lock,
+                     left_yx: Tuple[int, int],
+                     left_idx: Optional[int],
+                     right_yx: Tuple[int, int],
+                     right_idx: Optional[int],
+                     R: int,
+                     sim_cache: Optional[Dict[Tuple[int, int], float]],
                      override=None) -> float:
         return (
-            self._local_energy(left_yx, left_idx, R, sim_cache, cache_lock, override=override)
-            + self._local_energy(right_yx, right_idx, R, sim_cache, cache_lock, override=override)
+            self._local_energy(left_yx, left_idx, R, sim_cache, override=override)
+            + self._local_energy(right_yx, right_idx, R, sim_cache, override=override)
         )
 
     def _prepare_neighbors(self, radii: Iterable[int]) -> None:
@@ -174,22 +281,24 @@ class Layout2D:
             self.idx2cell[i] = yx;
             self._cell_owner_grid[yx[0]][yx[1]] = i
 
-        executor: Optional[ThreadPoolExecutor] = None
+        executor: Optional[ProcessPoolExecutor] = None
         if len(cells) > 1:
-            executor = ThreadPoolExecutor()
+            executor = ProcessPoolExecutor(
+                initializer=_init_worker_state,
+                initargs=(
+                    self._code_bitmasks,
+                    self._code_norms,
+                    self._aux_vecs,
+                    self._aux_weight,
+                ),
+            )
 
-        def evaluate_pair(ia, yxa, ib, yxb, radius, sim_cache, cache_lock):
-            override = ((yxa, ib), (yxb, ia))
-            e_cur = self._pair_energy(
-                yxa, ia, yxb, ib, radius,
-                sim_cache, cache_lock
-            )
-            e_swp = self._pair_energy(
-                yxa, ib, yxb, ia, radius,
-                sim_cache, cache_lock,
-                override=override
-            )
-            return ia, yxa, ib, yxb, e_cur, e_swp
+        state_for_local: WorkerState = (
+            self._code_bitmasks,
+            self._code_norms,
+            self._aux_vecs,
+            self._aux_weight,
+        )
 
         def pass_epoch(R: int, iters: int, phase: str):
             for ep in range(iters):
@@ -199,16 +308,30 @@ class Layout2D:
                 for i in range(0, len(occupied) - 1, 2):
                     (ia, yxa), (ib, yxb) = occupied[i], occupied[i + 1]
                     pairs.append((ia, yxa, ib, yxb))
-                sim_cache: Dict[Tuple[int, int], float] = {}
                 use_parallel = executor is not None and len(pairs) > 1
-                cache_lock = threading.Lock() if use_parallel else None
                 if not pairs:
                     if on_epoch: on_epoch(phase, ep, self)
                     continue
                 if not use_parallel:
+                    sim_cache: Dict[Tuple[int, int], float] = {}
                     for ia, yxa, ib, yxb in pairs:
-                        _, _, _, _, e_cur, e_swp = evaluate_pair(
-                            ia, yxa, ib, yxb, R, sim_cache, cache_lock
+                        neighbors_a: NeighborInfo = tuple(
+                            ((ny, nx), dist, self._cell_owner_grid[ny][nx])
+                            for (ny, nx), dist in self._neighbors(yxa[0], yxa[1], R)
+                        )
+                        neighbors_b: NeighborInfo = tuple(
+                            ((ny, nx), dist, self._cell_owner_grid[ny][nx])
+                            for (ny, nx), dist in self._neighbors(yxb[0], yxb[1], R)
+                        )
+                        _, _, _, _, e_cur, e_swp = _evaluate_pair_core(
+                            ia,
+                            yxa,
+                            ib,
+                            yxb,
+                            neighbors_a,
+                            neighbors_b,
+                            state=state_for_local,
+                            sim_cache=sim_cache,
                         )
                         if phase == "far":
                             if e_swp + 1e-9 < e_cur:
@@ -223,15 +346,20 @@ class Layout2D:
                                 self._cell_owner_grid[yxb[0]][yxb[1]] = ia
                                 if on_swap: on_swap(yxa, yxb, phase, ep, self)
                 else:
-                    futures = [
-                        executor.submit(
-                            evaluate_pair, ia, yxa, ib, yxb, R, sim_cache, cache_lock
+                    tasks = []
+                    for ia, yxa, ib, yxb in pairs:
+                        neighbors_a: NeighborInfo = tuple(
+                            ((ny, nx), dist, self._cell_owner_grid[ny][nx])
+                            for (ny, nx), dist in self._neighbors(yxa[0], yxa[1], R)
                         )
-                        for ia, yxa, ib, yxb in pairs
-                    ]
-                    wait(futures)
-                    for fut in futures:
-                        ia, yxa, ib, yxb, e_cur, e_swp = fut.result()
+                        neighbors_b: NeighborInfo = tuple(
+                            ((ny, nx), dist, self._cell_owner_grid[ny][nx])
+                            for (ny, nx), dist in self._neighbors(yxb[0], yxb[1], R)
+                        )
+                        tasks.append((ia, yxa, ib, yxb, neighbors_a, neighbors_b))
+                    for ia, yxa, ib, yxb, e_cur, e_swp in executor.map(
+                        evaluate_pair_worker, tasks
+                    ):
                         if phase == "far":
                             if e_swp + 1e-9 < e_cur:
                                 self.idx2cell[ia], self.idx2cell[ib] = yxb, yxa


### PR DESCRIPTION
## Резюме
- вынес логику сравнения кодов и оценки пар в сериализуемые вспомогательные функции
- заменил ThreadPoolExecutor на ProcessPoolExecutor и передал воркерам необходимые данные без общей блокировки GIL
- организовал локальные кэши сходства в главном процессе и отказался от совместного доступа к сетке ячеек

## Тестирование
- `python -m compileall src`


------
https://chatgpt.com/codex/tasks/task_e_68d1498c01fc832ea6ab618d45faff6b